### PR TITLE
Changed default logger configuration to be done on Moose metaclass name

### DIFF
--- a/etc/log4perl_tests.conf
+++ b/etc/log4perl_tests.conf
@@ -1,5 +1,4 @@
-log4perl.logger               = TRACE, A1
-log4perl.logger.dnap          = TRACE, A1
+log4perl.logger.WTSI.DNAP.Utilities = TRACE, A1
 
 log4perl.appender.A1          = Log::Log4perl::Appender::File
 log4perl.appender.A1.layout   = Log::Log4perl::Layout::PatternLayout

--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -21,3 +21,5 @@ functions = open opendir read readline readdir close closedir
 [-ValuesAndExpressions::ProhibitInterpolationOfLiterals]
 
 [-Variables::ProhibitPunctuationVars]
+
+[-Subroutines::ProhibitUnusedPrivateSubroutines]


### PR DESCRIPTION
Changed default logger configuration to be done on Moose metaclass name to enable per-class and class-hierarchy logging.