### PR TITLE
Disabled Miscellanea::RequireRcsKeywords

### DIFF
--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -9,6 +9,8 @@
 lib_sections    = AUTHOR
 script_sections = NAME | SYNOPSIS | DESCRIPTION | AUTHOR
 
+[-Miscellanea::RequireRcsKeywords]
+
 [-InputOutput::RequireBriefOpen]
 [-InputOutput::ProhibitBacktickOperators]
 [-InputOutput::RequireBracedFileHandleWithPrint]


### PR DESCRIPTION
Disabled Miscellanea::RequireRcsKeywords because git does not use RCS style keyword expansion.