### PR TITLE
use internal report_version to avoid caching issues with dist_version

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,6 @@
 .travis.yml
 Build.PL
+Changes
 COPYING
 etc/log4perl_tests.conf
 lib/WTSI/DNAP/Utilities.pm
@@ -16,6 +17,8 @@ lib/WTSI/DNAP/Utilities/Loggable/Redirected.pm
 lib/WTSI/DNAP/Utilities/Runnable.pm
 lib/WTSI/DNAP/Utilities/Startable.pm
 MANIFEST			This list of files
+META.json
+META.yml
 README
 t/bin/test_log_config.pl
 t/bin/true.sh

--- a/lib/WTSI/DNAP/Utilities/Build.pm
+++ b/lib/WTSI/DNAP/Utilities/Build.pm
@@ -147,9 +147,10 @@ sub _set_version {
   my ($self, @dirs) = @_;
   @dirs = grep { -d } @dirs;
 
+  my $version = $self->report_version;
   if (@dirs) {
     warn "Changing version of all modules and scripts to '" .
-      $self->dist_version . "'\n";
+      $version . "'\n";
 
     find({'follow'   => 0,
           'no_chdir' => 1,
@@ -162,7 +163,7 @@ sub _set_version {
               local @ARGV = ($module);
 
               while (my $line = <>) {
-                $self->_transform($line);
+                $self->_transform($version, $line);
               }
 
               unlink "$module$backup";
@@ -175,8 +176,7 @@ sub _set_version {
 }
 
 sub _transform {
-  my ($self, $line) = @_;
-  my $version = $self->dist_version;
+  my ($self, $version, $line) = @_;
 
   ##no critic (RequireExtendedFormatting RequireLineBoundaryMatching)
   ##no critic (RequireDotMatchAnything ProhibitUnusedCapture)

--- a/lib/WTSI/DNAP/Utilities/Build.pm
+++ b/lib/WTSI/DNAP/Utilities/Build.pm
@@ -128,7 +128,7 @@ sub ACTION_dist {
   print "Creating dist version file $version_file\n";
   open my $fh, '>', $version_file or
     die "Failed to open $version_file for writing: $!\n";
-  print $fh $self->dist_version, "\n";
+  print $fh $self->report_version, "\n";
   close $fh or carp "Failed to close $version_file cleanly\n";
 
   # If this is a repository, set the dist version from git

--- a/lib/WTSI/DNAP/Utilities/Build.pm
+++ b/lib/WTSI/DNAP/Utilities/Build.pm
@@ -69,7 +69,7 @@ sub report_version {
       die "Failed to open $DIST_VERSION_FILE for reading: $!\n";
     $version = <$fh>;
     chomp $version;
-    close $fh or carp "Failed to clode $DIST_VERSION_FILE cleanly\n";
+    close $fh or carp "Failed to close $DIST_VERSION_FILE cleanly\n";
   }
   else {
     $version = $self->git_tag;


### PR DESCRIPTION
`./Build` should update versions in `blib` using git describe info if possible rather than use cached info from time of running `perl Build.PL`. It used to work like this but perhaps a recent change to `Module::Build` requires these changes?